### PR TITLE
Cargo.toml: Avoid mixing old libc 0.2.172

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,7 +336,7 @@ jiff = { version = "0.2.10", default-features = false, features = [
   "alloc",
   "tz-system",
 ] }
-libc = "0.2.172"
+libc = "0.2.178"
 linux-raw-sys = "0.12"
 lscolors = { version = "0.21.0", default-features = false, features = [
   "gnu_legacy",


### PR DESCRIPTION
https://github.com/uutils/coreutils/pull/8722#issuecomment-3626389705
At AUR/MSYS package with `cargo update -p libc` hack:
```
   Compiling libc v0.2.175
   Compiling libc v0.2.178 (/tmp/makepkg/uutils-coreutils-git/src/libc-0.2.178)
```
Not sure is it related with FreeBSD's err.